### PR TITLE
fix: lint example/gen and handle existing issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 # GolangCI-Lint Configuration
 
-run:
-  skip-dirs:
-    - example/gen
+issues:
+  exclude-rules:
+    - path: example/gen
+      linters:
+        - unused

--- a/core/codegen/build.conv.go
+++ b/core/codegen/build.conv.go
@@ -149,8 +149,8 @@ func (b *convBuilder) buildFile(elem dbtype.Element) error {
 			Block(
 				jen.Id("raw").Op(":=").String().Call(jen.Id("data")),
 				jen.If(
-					jen.Qual("strings", "HasPrefix").Call(jen.Id("raw"), jen.Lit("\"")),
-					jen.Qual("strings", "HasSuffix").Call(jen.Id("raw"), jen.Lit("\"")),
+					jen.Qual("strings", "HasPrefix").Call(jen.Id("raw"), jen.Lit("\"")).
+						Op("&&").Qual("strings", "HasSuffix").Call(jen.Id("raw"), jen.Lit("\"")),
 				).
 					Block(
 						jen.Id("raw").Op("=").Id("raw").Index(jen.Lit(1).Op(":").Len(jen.Id("raw")).Op("-").Lit(1)),

--- a/core/codegen/build.relate.go
+++ b/core/codegen/build.relate.go
@@ -85,7 +85,7 @@ func (b *relateBuilder) buildNodeFile(node *dbtype.Node) error {
 			Id(fld.NameGo()).Params().
 			Id(strcase.ToLowerCamel(edge)).
 			Block(
-				jen.Return(jen.Id(strcase.ToLowerCamel(edge)).Values(jen.Id("db").Op(":").Id("n").Dot("db"))),
+				jen.Return(jen.Id(strcase.ToLowerCamel(edge)).Call(jen.Id("n"))),
 			)
 	}
 

--- a/example/gen/som/conv/node.group.go
+++ b/example/gen/som/conv/node.group.go
@@ -38,7 +38,7 @@ func (f *GroupField) MarshalJSON() ([]byte, error) {
 }
 func (f *GroupField) UnmarshalJSON(data []byte) error {
 	raw := string(data)
-	if strings.HasPrefix(raw, "\""); strings.HasSuffix(raw, "\"") {
+	if strings.HasPrefix(raw, "\"") && strings.HasSuffix(raw, "\"") {
 		raw = raw[1 : len(raw)-1]
 		f.ID = parseDatabaseID("group", raw)
 		return nil

--- a/example/gen/som/conv/node.user.go
+++ b/example/gen/som/conv/node.user.go
@@ -89,7 +89,7 @@ func (f *UserField) MarshalJSON() ([]byte, error) {
 }
 func (f *UserField) UnmarshalJSON(data []byte) error {
 	raw := string(data)
-	if strings.HasPrefix(raw, "\""); strings.HasSuffix(raw, "\"") {
+	if strings.HasPrefix(raw, "\"") && strings.HasSuffix(raw, "\"") {
 		raw = raw[1 : len(raw)-1]
 		f.ID = parseDatabaseID("user", raw)
 		return nil

--- a/example/gen/som/relate/node.group.go
+++ b/example/gen/som/relate/node.group.go
@@ -9,5 +9,5 @@ type Group struct {
 }
 
 func (n Group) Members() memberOf {
-	return memberOf{db: n.db}
+	return memberOf(n)
 }

--- a/example/gen/som/relate/node.user.go
+++ b/example/gen/som/relate/node.user.go
@@ -9,5 +9,5 @@ type User struct {
 }
 
 func (n User) MyGroups() memberOf {
-	return memberOf{db: n.db}
+	return memberOf(n)
 }


### PR DESCRIPTION
Follow-up of #51 and #52.

This PR configures golangci-lint to also check the example/gen folder for issues. The existing issues are fixed with this PR as well.