### PR TITLE
feat: implement select, update and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A type-safe database access layer with code generation for [SurrealDB](https://surrealdb.com).
 
+## Table of contents
+
+* [Getting started](#getting-started)
+  * [Basic usage](#basic-usage)
+  * [Versioning](#versioning)
+  * [Compatibility](#compatibility)
+  * [Features](#features)
+* [Roadmap](#roadmap)
+* [How to contribute](#how-to-contribute)
+* [Maintainers & Contributors](#maintainers--contributors)
+* [References](#references)
+
 ## Getting started
 
 ### Usage
@@ -12,7 +24,7 @@ Generate the client code:
 go run github.com/marcbinz/som/cmd/somgen@latest <input_dir> <output_dir>
 ```
 
-The package `github.com/marcbinz/sdb` is a dependency for the project in which the generated client code is used.
+The package `github.com/marcbinz/som` is a dependency for the project in which the generated client code is used.
 So it must be added to the `go.mod` file accordingly.
 
 ### Versioning

--- a/example/gen/som/node.user.go
+++ b/example/gen/som/node.user.go
@@ -38,17 +38,35 @@ func (n *user) Create(ctx context.Context, user *model.User) error {
 	*user = *conv.ToUser(&convNode)
 	return nil
 }
-func (n *user) Update(ctx context.Context, user *model.User) error {
-	if user.ID != "" {
-		return errors.New("ID must not be set for a node to be created")
+func (n *user) Read(ctx context.Context, id string) (*model.User, bool, error) {
+	raw, err := n.client.db.Select("user:" + id)
+	if err != nil {
+		if errors.As(err, &surrealdbgo.PermissionError{}) {
+			return nil, false, nil
+		}
+		return nil, false, err
 	}
-	data := conv.FromUser(user)
-	raw, err := n.client.db.Update("user", data)
+	var convNode *conv.User
+	err = surrealdbgo.Unmarshal([]any{raw}, &convNode)
+	if err != nil {
+		return nil, false, err
+	}
+	return conv.ToUser(convNode), true, nil
+}
+func (n *user) Update(ctx context.Context, user *model.User) error {
+	if user.ID == "" {
+		return errors.New("cannot update User without existing record ID")
+	}
+	data, err := toMap(conv.FromUser(user))
+	if err != nil {
+		return err
+	}
+	raw, err := n.client.db.Update("user:"+user.ID, data)
 	if err != nil {
 		return err
 	}
 	var convNode conv.User
-	err = surrealdbgo.Unmarshal(raw, &convNode)
+	err = surrealdbgo.Unmarshal([]any{raw}, &convNode)
 	if err != nil {
 		return err
 	}
@@ -56,6 +74,10 @@ func (n *user) Update(ctx context.Context, user *model.User) error {
 	return nil
 }
 func (n *user) Delete(ctx context.Context, user *model.User) error {
+	_, err := n.client.db.Delete("user:" + user.ID)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 func (n *user) Relate() *relate.User {

--- a/example/gen/som/util.go
+++ b/example/gen/som/util.go
@@ -1,0 +1,20 @@
+package som
+
+import (
+	"encoding/json"
+)
+
+func toMap(val any) (map[string]any, error) {
+	data, err := json.Marshal(val)
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string]any
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/example/repo/user.go
+++ b/example/repo/user.go
@@ -12,6 +12,10 @@ import (
 
 type UserRepo interface {
 	Create(ctx context.Context, user *model.User) error
+	Read(ctx context.Context, id string) (*model.User, bool, error)
+	Update(ctx context.Context, u *model.User) error
+	Delete(ctx context.Context, u *model.User) error
+
 	FindById(ctx context.Context, id string) (*model.User, error)
 	List(ctx context.Context) ([]*model.User, error)
 	Relate(ctx context.Context, edge *model.MemberOf) error
@@ -27,6 +31,18 @@ func User(db *som.Client) UserRepo {
 
 func (repo *user) Create(ctx context.Context, user *model.User) error {
 	return repo.db.User().Create(ctx, user)
+}
+
+func (repo *user) Read(ctx context.Context, id string) (*model.User, bool, error) {
+	return repo.db.User().Read(ctx, id)
+}
+
+func (repo *user) Update(ctx context.Context, user *model.User) error {
+	return repo.db.User().Update(ctx, user)
+}
+
+func (repo *user) Delete(ctx context.Context, user *model.User) error {
+	return repo.db.User().Delete(ctx, user)
 }
 
 func (repo *user) FindById(ctx context.Context, id string) (*model.User, error) {

--- a/som.go
+++ b/som.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+type Record = Node // TODO: should we use this?
+
 type Node struct {
 	// include query info into each node resulting from a query?:
 	// status string

--- a/test/main.go
+++ b/test/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/marcbinz/som/example/gen/som"
 	"github.com/marcbinz/som/example/model"
 	"github.com/marcbinz/som/example/repo"
@@ -64,9 +65,38 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("relation:", edge.ID)
-	fmt.Println("user:", edge.User.ID)
-	fmt.Println("group:", edge.Group.ID)
+	user, ok, err := userRepo.Read(ctx, user.ID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !ok {
+		log.Fatal("could not find user with id:", user.ID)
+	}
+
+	// fmt.Println("relation:", edge.ID)
+	// fmt.Println("user:", edge.User.ID)
+	// fmt.Println("group:", edge.Group.ID)
+
+	fmt.Println("old user uuid:", user.UUID, user.ID)
+
+	user.UUID, _ = uuid.NewUUID()
+
+	fmt.Println("new user uuid:", user.UUID, user.ID)
+
+	err = userRepo.Update(ctx, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("updated user uuid:", user.UUID, user.ID)
+
+	err = userRepo.Delete(ctx, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("deleted user:", user.ID)
 
 	//
 	// user2, err := userRepo.FindById(ctx, user.ID)


### PR DESCRIPTION
This PR finally implements the missing methods for `update` and `delete` of the nodes.

Furthermore it reactivates the `read` (aka select) method that was disabled before.