### PR TITLE
fix: query variable index breaks after 26 variables

### DIFF
--- a/example/som_test.go
+++ b/example/som_test.go
@@ -42,7 +42,7 @@ func TestQuery(t *testing.T) {
 		).
 		Describe()
 
-	assert.Equal(t, "SELECT * FROM user WHERE (string INSIDE $A AND bool == $B AND (time_ptr == $C OR uuid = $D)) ", query)
+	assert.Equal(t, "SELECT * FROM user WHERE (string INSIDE $0 AND bool == $1 AND (time_ptr == $2 OR uuid = $3)) ", query)
 }
 
 func TestWithDatabase(t *testing.T) {

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -7,12 +7,12 @@ import (
 )
 
 type context struct {
-	varIndex rune
+	varIndex int
 	vars     map[string]any
 }
 
 func (c *context) asVar(val any) string {
-	index := string(c.varIndex)
+	index := strconv.Itoa(c.varIndex)
 	c.vars[index] = val
 	c.varIndex++
 	return "$" + index
@@ -36,7 +36,7 @@ type Query struct {
 func NewQuery(node string) *Query {
 	return &Query{
 		context: &context{
-			varIndex: 'A',
+			varIndex: 0,
 			vars:     map[string]any{},
 		},
 		node: node,


### PR DESCRIPTION
Using a rune for the query variable index is not well suited, due to it breaking out of the ABC after 26 variables (after the Z).

This PR simply switches the variable names to integer values starting to count from `0` upwards.