### PR TITLE
refactor: provide separate create-with-id method

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ language itself. For further information, please refer to the
 - [ ] Choose proper licensing for the project. (#11)
 - [ ] Provide `WithInfo` method.
 - [ ] Support (deeply) nested slices? (needed?)
-- [ ] `db.User.CreateWithID(customID, model)`
+- [ ] Add query `where.User.Equal(userModel)`? Prevent clash by appending `_` where necessary?
 
 ### After v0.1.0
 

--- a/core/codegen/base.builder.go
+++ b/core/codegen/base.builder.go
@@ -330,13 +330,68 @@ func (b *build) buildBaseFile(node *field.NodeTable) error {
 					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("the passed node must not be nil"))),
 				),
 
-			// TODO: maybe add an option to the generator: "strict" vs. "non-strict" mode (regarding custom IDs)?
-			jen.Id("key").Op(":=").Lit(node.NameDatabase()),
-			jen.If(jen.Id(node.NameGoLower()).Dot("ID").Op("!=").Lit("")).
+			jen.If(jen.Id(node.NameGoLower()).Dot("ID").Call().Op("!=").Lit("")).
 				Block(
-					jen.Id("key").Op("+=").
-						Lit(":").Op("+").Lit("⟨").Op("+").Id(node.NameGoLower()).Dot("ID").Op("+").Lit("⟩"),
+					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("creating node with preset ID not allowed, use CreateWithID for that"))),
 				),
+
+			jen.Id("key").Op(":=").Lit(node.NameDatabase()),
+			jen.Id("data").Op(":=").Qual(pkgConv, "From"+node.NameGo()).Call(jen.Op("*").Id(node.NameGoLower())),
+
+			jen.Add(onCreatedAt),
+			jen.Add(onUpdatedAt),
+
+			jen.Id("raw").Op(",").Err().Op(":=").
+				Id("n").Dot("client").Dot("db").Dot("Create").
+				Call(jen.Id("key"), jen.Id("data")),
+			jen.If(jen.Err().Op("!=").Nil()).Block(
+				jen.Return(jen.Err()),
+			),
+
+			jen.If(
+				jen.List(jen.Id("_"), jen.Id("ok")).Op(":=").
+					Id("raw").Op(".").Call(jen.Index().Any()),
+				jen.Op("!").Id("ok"),
+			).Block(
+				jen.Id("raw").Op("=").Index().Any().Values(jen.Id("raw")).Comment("temporary fix"),
+			),
+
+			jen.Var().Id("convNode").Qual(b.subPkg(def.PkgConv), node.NameGo()),
+			jen.Err().Op("=").Qual(def.PkgSurrealDB, "Unmarshal").
+				Call(jen.Id("raw"), jen.Op("&").Id("convNode")),
+			jen.If(jen.Err().Op("!=").Nil()).Block(
+				jen.Return(jen.Err()),
+			),
+
+			jen.Op("*").Id(node.NameGoLower()).Op("=").
+				Qual(b.subPkg(def.PkgConv), "To"+node.NameGo()).
+				Call(jen.Id("convNode")),
+
+			jen.Return(jen.Nil()),
+		)
+
+	f.Func().
+		Params(jen.Id("n").Op("*").Id(node.NameGoLower())).
+		Id("CreateWithID").
+		Params(
+			jen.Id("ctx").Qual("context", "Context"),
+			jen.Id("id").String(), // TODO: name clash if node/model is named "id"!
+			jen.Id(node.NameGoLower()).Op("*").Add(b.input.SourceQual(node.NameGo())),
+		).
+		Error().
+		Block(
+			jen.If(jen.Id(node.NameGoLower()).Op("==").Nil()).
+				Block(
+					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("the passed node must not be nil"))),
+				),
+
+			jen.If(jen.Id(node.NameGoLower()).Dot("ID").Call().Op("!=").Lit("")).
+				Block(
+					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("creating node with preset ID not allowed, use CreateWithID for that"))),
+				),
+
+			jen.Id("key").Op(":=").Lit(node.NameDatabase()+":").Op("+").
+				Lit("⟨").Op("+").Id("id").Op("+").Lit("⟩"),
 			jen.Id("data").Op(":=").Qual(pkgConv, "From"+node.NameGo()).Call(jen.Op("*").Id(node.NameGoLower())),
 
 			jen.Add(onCreatedAt),
@@ -426,7 +481,7 @@ func (b *build) buildBaseFile(node *field.NodeTable) error {
 					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("the passed node must not be nil"))),
 				),
 
-			jen.If(jen.Id(node.NameGoLower()).Dot("ID").Op("==").Lit("")).
+			jen.If(jen.Id(node.NameGoLower()).Dot("ID").Call().Op("==").Lit("")).
 				Block(
 					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("cannot update "+node.NameGo()+" without existing record ID"))),
 				),
@@ -437,7 +492,7 @@ func (b *build) buildBaseFile(node *field.NodeTable) error {
 
 			jen.Id("raw").Op(",").Err().Op(":=").
 				Id("n").Dot("client").Dot("db").Dot("Update").
-				Call(jen.Lit(node.NameDatabase()+":⟨").Op("+").Id(node.NameGoLower()).Dot("ID").Op("+").Lit("⟩"), jen.Id("data")),
+				Call(jen.Lit(node.NameDatabase()+":⟨").Op("+").Id(node.NameGoLower()).Dot("ID").Call().Op("+").Lit("⟩"), jen.Id("data")),
 			jen.If(jen.Err().Op("!=").Nil()).Block(
 				jen.Return(jen.Err()),
 			),
@@ -471,7 +526,7 @@ func (b *build) buildBaseFile(node *field.NodeTable) error {
 
 			jen.List(jen.Id("_"), jen.Err()).Op(":=").
 				Id("n").Dot("client").Dot("db").Dot("Delete").
-				Call(jen.Lit(node.NameDatabase()+":⟨").Op("+").Id(node.NameGoLower()).Dot("ID").Op("+").Lit("⟩")),
+				Call(jen.Lit(node.NameDatabase()+":⟨").Op("+").Id(node.NameGoLower()).Dot("ID").Call().Op("+").Lit("⟩")),
 			jen.If(jen.Err().Op("!=").Nil()).Block(
 				jen.Return(jen.Err()),
 			),

--- a/core/codegen/build.conv.go
+++ b/core/codegen/build.conv.go
@@ -311,8 +311,8 @@ func (b *convBuilder) buildTo(elem field.Element) jen.Code {
 				}
 
 				if _, ok := elem.(*field.NodeTable); ok {
-					d[jen.Id("Node")] = jen.Qual(def.PkgSom, "Node").Values(
-						jen.Id("ID").Op(":").Id("parseDatabaseID").Call(
+					d[jen.Id("Node")] = jen.Qual(def.PkgSom, "NewNode").Call(
+						jen.Id("parseDatabaseID").Call(
 							jen.Lit(elem.NameDatabase()),
 							jen.Id("data").Dot("ID"),
 						),
@@ -320,8 +320,8 @@ func (b *convBuilder) buildTo(elem field.Element) jen.Code {
 				}
 
 				if _, ok := elem.(*field.EdgeTable); ok {
-					d[jen.Id("Edge")] = jen.Qual(def.PkgSom, "Edge").Values(
-						jen.Id("ID").Op(":").Id("parseDatabaseID").Call(
+					d[jen.Id("Edge")] = jen.Qual(def.PkgSom, "NewEdge").Call(
+						jen.Id("parseDatabaseID").Call(
 							jen.Lit(elem.NameDatabase()),
 							jen.Id("data").Dot("ID"),
 						),

--- a/core/codegen/build.relate.go
+++ b/core/codegen/build.relate.go
@@ -118,25 +118,25 @@ func (b *relateBuilder) buildEdgeFile(edge *field.EdgeTable) error {
 					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("the given edge must not be nil"))),
 				),
 
-			jen.If(jen.Id("edge").Dot("ID").Op("!=").Lit("")).
+			jen.If(jen.Id("edge").Dot("ID").Call().Op("!=").Lit("")).
 				Block(
 					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("ID must not be set for an edge to be created"))),
 				),
 
-			jen.If(jen.Id("edge").Dot(edge.In.NameGo()).Dot("ID").Op("==").Lit("")).
+			jen.If(jen.Id("edge").Dot(edge.In.NameGo()).Dot("ID").Call().Op("==").Lit("")).
 				Block(
 					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("ID of the incoming node '"+edge.In.NameGo()+"' must not be empty"))),
 				),
 
-			jen.If(jen.Id("edge").Dot(edge.Out.NameGo()).Dot("ID").Op("==").Lit("")).
+			jen.If(jen.Id("edge").Dot(edge.Out.NameGo()).Dot("ID").Call().Op("==").Lit("")).
 				Block(
 					jen.Return(jen.Qual("errors", "New").Call(jen.Lit("ID of the outgoing node '"+edge.Out.NameGo()+"' must not be empty"))),
 				),
 
 			jen.Id("query").Op(":=").Lit("RELATE "),
-			jen.Id("query").Op("+=").Lit(edge.In.NameDatabase()+":").Op("+").Id("edge").Dot(edge.In.NameGo()).Dot("ID"),
+			jen.Id("query").Op("+=").Lit(edge.In.NameDatabase()+":").Op("+").Id("edge").Dot(edge.In.NameGo()).Dot("ID").Call(),
 			jen.Id("query").Op("+=").Lit("->"+edge.NameDatabase()+"->"),
-			jen.Id("query").Op("+=").Lit(edge.Out.NameDatabase()+":").Op("+").Id("edge").Dot(edge.Out.NameGo()).Dot("ID"),
+			jen.Id("query").Op("+=").Lit(edge.Out.NameDatabase()+":").Op("+").Id("edge").Dot(edge.Out.NameGo()).Dot("ID").Call(),
 			jen.Id("query").Op("+=").Lit(" CONTENT $data"),
 
 			jen.Id("data").Op(":=").Qual(b.subPkg(def.PkgConv), "From"+edge.NameGo()).Call(jen.Op("*").Id("edge")),

--- a/example/gen/som/conv/edge.member_of.go
+++ b/example/gen/som/conv/edge.member_of.go
@@ -19,7 +19,7 @@ func FromMemberOf(data model.MemberOf) MemberOf {
 }
 func ToMemberOf(data MemberOf) model.MemberOf {
 	return model.MemberOf{
-		Edge:       som.Edge{ID: parseDatabaseID("member_of", data.ID)},
+		Edge:       som.NewEdge(parseDatabaseID("member_of", data.ID)),
 		Meta:       toMemberOfMeta(data.Meta),
 		Timestamps: som.NewTimestamps(data.CreatedAt, data.UpdatedAt),
 	}

--- a/example/gen/som/conv/node.group.go
+++ b/example/gen/som/conv/node.group.go
@@ -24,7 +24,7 @@ func ToGroup(data Group) model.Group {
 	return model.Group{
 		Members:    mapSlice(data.Members, ToMemberOf),
 		Name:       data.Name,
-		Node:       som.Node{ID: parseDatabaseID("group", data.ID)},
+		Node:       som.NewNode(parseDatabaseID("group", data.ID)),
 		Timestamps: som.NewTimestamps(data.CreatedAt, data.UpdatedAt),
 	}
 }

--- a/example/gen/som/conv/node.user.go
+++ b/example/gen/som/conv/node.user.go
@@ -94,7 +94,7 @@ func ToUser(data User) model.User {
 		MainGroup:         fromGroupLink(data.MainGroup),
 		More:              data.More,
 		MyGroups:          mapSlice(data.MyGroups, ToMemberOf),
-		Node:              som.Node{ID: parseDatabaseID("user", data.ID)},
+		Node:              som.NewNode(parseDatabaseID("user", data.ID)),
 		NodePtrSlice:      mapPtrSlice(data.NodePtrSlice, fromGroupLink),
 		NodePtrSlicePtr:   mapPtrSlicePtr(data.NodePtrSlicePtr, fromGroupLink),
 		Other:             data.Other,

--- a/example/gen/som/relate/edge.member_of.go
+++ b/example/gen/som/relate/edge.member_of.go
@@ -16,19 +16,19 @@ func (e memberOf) Create(edge *model.MemberOf) error {
 	if edge == nil {
 		return errors.New("the given edge must not be nil")
 	}
-	if edge.ID != "" {
+	if edge.ID() != "" {
 		return errors.New("ID must not be set for an edge to be created")
 	}
-	if edge.User.ID == "" {
+	if edge.User.ID() == "" {
 		return errors.New("ID of the incoming node 'User' must not be empty")
 	}
-	if edge.Group.ID == "" {
+	if edge.Group.ID() == "" {
 		return errors.New("ID of the outgoing node 'Group' must not be empty")
 	}
 	query := "RELATE "
-	query += "user:" + edge.User.ID
+	query += "user:" + edge.User.ID()
 	query += "->member_of->"
-	query += "group:" + edge.Group.ID
+	query += "group:" + edge.Group.ID()
 	query += " CONTENT $data"
 	data := conv.FromMemberOf(*edge)
 	raw, err := e.db.Query(query, map[string]any{"data": data})

--- a/example/som_test.go
+++ b/example/som_test.go
@@ -171,13 +171,13 @@ func FuzzWithDatabase(f *testing.F) {
 			t.Error(err)
 		}
 
-		if userIn.ID == "" {
+		if userIn.ID() == "" {
 			t.Error("user ID must not be empty after create call")
 		}
 
 		userOut, err := client.User().Query().
 			Filter(
-				where.User.ID.Equal(userIn.ID),
+				where.User.ID.Equal(userIn.ID()),
 			).
 			First()
 
@@ -247,28 +247,26 @@ func FuzzCustomModelIDs(f *testing.F) {
 			String: "1",
 		}
 
-		userIn.ID = id
-
-		err = client.User().Create(ctx, userIn)
+		err = client.User().CreateWithID(ctx, id, userIn)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if userIn.ID == "" {
+		if userIn.ID() == "" {
 			t.Error("user ID must not be empty after create call")
 		}
 
-		userOut, ok, err := client.User().Read(ctx, userIn.ID)
+		userOut, ok, err := client.User().Read(ctx, userIn.ID())
 
 		if err != nil {
 			t.Error(err)
 		}
 
 		if !ok {
-			t.Errorf("user with ID %s not found", userIn.ID)
+			t.Errorf("user with ID %s not found", userIn.ID())
 		}
 
-		assert.Equal(t, userIn.ID, userOut.ID)
+		assert.Equal(t, userIn.ID(), userOut.ID())
 		assert.Equal(t, "1", userOut.String)
 
 		userOut.String = "2"
@@ -337,13 +335,13 @@ func BenchmarkWithDatabase(b *testing.B) {
 			b.Error(err)
 		}
 
-		if userIn.ID == "" {
+		if userIn.ID() == "" {
 			b.Error("user ID must not be empty after create call")
 		}
 
 		userOut, err := client.User().Query().
 			Filter(
-				where.User.ID.Equal(userIn.ID),
+				where.User.ID.Equal(userIn.ID()),
 			).
 			First()
 

--- a/som.go
+++ b/som.go
@@ -4,20 +4,36 @@ import (
 	"time"
 )
 
-type Record = Node // TODO: should we use this?
+// type Record = Node // TODO: should we use this to clarify whether a model has edges (node) or not (record)?
 
 type Node struct {
-	ID string
-	// include query info into each node resulting from a query?:
-	// status string
-	// time   string
-	// extract via som.Info(someNode) -> som.Info ?
+	id string
+}
+
+func NewNode(id string) Node {
+	return Node{
+		id: id,
+	}
+}
+
+func (n Node) ID() string {
+	return n.id
 }
 
 // Edge describes an edge between two Node elements.
 // It may have its own fields.
 type Edge struct {
-	ID string
+	id string
+}
+
+func NewEdge(id string) Edge {
+	return Edge{
+		id: id,
+	}
+}
+
+func (e Edge) ID() string {
+	return e.id
 }
 
 type Timestamps struct {
@@ -40,19 +56,20 @@ func (t Timestamps) UpdatedAt() time.Time {
 	return t.updatedAt
 }
 
-type SoftDelete struct {
-	deletedAt time.Time
-}
-
-func NewSoftDelete(deletedAt time.Time) SoftDelete {
-	return SoftDelete{
-		deletedAt: deletedAt,
-	}
-}
-
-func (t SoftDelete) DeletedAt() time.Time {
-	return t.deletedAt
-}
+// TODO: implement soft delete feature
+// type SoftDelete struct {
+// 	deletedAt time.Time
+// }
+//
+// func NewSoftDelete(deletedAt time.Time) SoftDelete {
+// 	return SoftDelete{
+// 		deletedAt: deletedAt,
+// 	}
+// }
+//
+// func (t SoftDelete) DeletedAt() time.Time {
+// 	return t.deletedAt
+// }
 
 // Enum describes a database type with a fixed set of allowed values.
 type Enum string
@@ -60,14 +77,15 @@ type Enum string
 // Password describes a special string field.
 // Regarding the generated database query operations, it can only be matched, but never read.
 // In a query result, the Password field will always be empty.
-type Password string
+// TODO: implement!
+// type Password string
 
 // Meta describes a model that is not related to any Node or Edge.
 // Instead, it is used to hold metadata that was queried from a Node or Edge.
 //
 // Applying this struct to a type within your model package will ensure
 // that this type is never considered for the generated layer.
-type Meta struct{}
+// type Meta struct{}
 
 // Info holds information about a single database operation.
 // It is used as target to hold said information when building
@@ -86,16 +104,19 @@ type Meta struct{}
 //
 // Please note: When using the same base for multiple operations, the Info
 // struct will only ever hold the information of the last operation.
-type Info struct {
-	Time    time.Time
-	Status  string
-	Message string
-}
+// TODO: implement!
+// type Info struct {
+// 	Time    time.Time
+// 	Status  string
+// 	Message string
+// }
 
-type Entity interface {
-	entity()
-}
+// TODO: below needed?
+// type Entity interface {
+// 	entity()
+// }
 
-type External struct {
-	ID string
-}
+// TODO: implement external types
+// type External struct {
+// 	ID string
+// }

--- a/test/main.go
+++ b/test/main.go
@@ -41,7 +41,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("group:", group.ID, group.Name, group.CreatedAt())
+	fmt.Println("group:", group.ID(), group.Name, group.CreatedAt())
 
 	user := &model.User{
 		String:    "Marc",
@@ -53,7 +53,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("user:", user.ID, user.String, user.CreatedAt(), user.UpdatedAt().IsZero())
+	fmt.Println("user:", user.ID(), user.String, user.CreatedAt(), user.UpdatedAt().IsZero())
 
 	edge := &model.MemberOf{
 		User:  *user,
@@ -68,34 +68,34 @@ func main() {
 		log.Fatal(err)
 	}
 
-	user, ok, err := db.User().Read(ctx, user.ID)
+	user, ok, err := db.User().Read(ctx, user.ID())
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	if !ok {
-		log.Fatal("could not find user with id:", user.ID)
+		log.Fatal("could not find user with id:", user.ID())
 	}
 
 	// fmt.Println("relation:", edge.ID)
 	// fmt.Println("user:", edge.User.ID)
 	// fmt.Println("group:", edge.Group.ID)
 
-	fmt.Println("old user uuid:", user.UUID, user.ID, user.UpdatedAt())
+	fmt.Println("old user uuid:", user.UUID, user.ID(), user.UpdatedAt())
 
 	user.UUID = uuid.New()
 
 	value := "some value"
 	user.StringPtr = &value
 
-	fmt.Println("new user uuid:", user.UUID, user.ID)
+	fmt.Println("new user uuid:", user.UUID, user.ID())
 
 	err = db.User().Update(ctx, user)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println("updated user uuid:", user.UUID, user.ID, user.UpdatedAt())
+	fmt.Println("updated user uuid:", user.UUID, user.ID(), user.UpdatedAt())
 
 	query := db.User().Query().
 		Filter(
@@ -138,7 +138,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("deleted user:", user.ID)
+	fmt.Println("deleted user:", user.ID())
 
 	//
 	// user2, err := userRepo.FindById(ctx, user.ID)


### PR DESCRIPTION
Follow-up of #68.

Moves the ability to set a custom record ID to a new dedicated method. Makes the ID property only accessible via a separate getter method.